### PR TITLE
chore: improve workflow display names in GitHub Actions UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   release:
-    name: release
+    name: Build and Publish to RubyGems
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/schema-compat.yml
+++ b/.github/workflows/schema-compat.yml
@@ -7,6 +7,7 @@
 # or manually via workflow_dispatch.
 
 name: Schema Compatibility Check
+run-name: "Schema Compatibility Check — ParadeDB v${{ inputs.version || github.event.client_payload.version }}"
 
 on:
   repository_dispatch:


### PR DESCRIPTION
## Summary
- Add `run-name` to `schema-compat` workflow so `repository_dispatch` runs show a descriptive title (e.g. "Schema Compatibility Check — ParadeDB v0.15.1") instead of the raw event type
- Rename the `release` job to "Build and Publish to RubyGems" for clarity

## Test plan
- [x] Trigger a schema-compat run via `workflow_dispatch` and verify the run name displays correctly
- [x] Verify the release job name shows correctly in the Actions UI