### PR TITLE
ci: drop Slack @here notification from schema-compat failure

### DIFF
--- a/.github/workflows/schema-compat.yml
+++ b/.github/workflows/schema-compat.yml
@@ -114,9 +114,3 @@ jobs:
           EOF
           )" \
             --label bug
-
-      - name: Notify Slack on Failure
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`schema-compat\` workflow failed for ParadeDB v${{ env.PARADEDB_VERSION }} in \`${{ github.repository }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Removes the `Notify Slack on Failure` step from `.github/workflows/schema-compat.yml` so failed schema-compat runs no longer page `<!here>` in Slack.
- Matches `django-paradedb`, which only files a GitHub issue on failure. The auto-filed GitHub issue is preserved here.

## Test plan
- [x] Next `repository_dispatch: paradedb-release` (or a manual `workflow_dispatch`) on this branch fails intentionally and only a GitHub issue is created — no Slack message.