### PR TITLE
ci: Use GITHUB_TOKEN instead of PARADEDB_BOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -52,7 +50,7 @@ jobs:
 
       - name: Validate version and release state
         env:
-          GITHUB_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -117,7 +115,7 @@ jobs:
           generate_release_notes: true
           files: rails-paradedb-${{ env.VERSION }}.gem
         env:
-          GITHUB_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Use the normal GITHUB_TOKEN here so we don't depend on the ParadeDB bot

## Why

## How

## Tests
