### PR TITLE
ci: Disable uv cache to fix dependency-glob annotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
 
       - name: Run RuboCop lint cops
         run: |

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
 
       - name: Run Beautysh
         run: |


### PR DESCRIPTION
## Problem

CI surfaces a warning annotation:

> No file matched to [...*requirements*.txt, ...pyproject.toml, ...uv.lock, ...]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.

This comes from `astral-sh/setup-uv@v7` with `enable-cache: true`. The cache is keyed off Python dependency files (requirements/pyproject/uv.lock), but this repo has **none** — `uv` is only used for ephemeral `uv run --with json5` and `uv tool run` invocations. So the cache can never be invalidated and provides no benefit.

## Fix

Remove `enable-cache: true` (defaults to `false`) from the workflows that set up uv. This drops the useless cache and clears the annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)