### PR TITLE
fix: built-in ArgumentError in tokenizer

### DIFF
--- a/lib/parade_db/tokenizer.rb
+++ b/lib/parade_db/tokenizer.rb
@@ -90,7 +90,7 @@ module ParadeDB
       when String
         quote_term(value)
       else
-        raise InvalidArgumentError, "Unsupported tokenizer arg type: #{value.class}"
+        raise ArgumentError, "Unsupported tokenizer arg type: #{value.class}"
       end
     end
   end


### PR DESCRIPTION
## Summary

### Bug — `NameError` instead of the intended argument error (`lib/parade_db/tokenizer.rb:92`)

`Tokenizer#render_positional_arg` raised `InvalidArgumentError` for unsupported arg types:

```ruby
raise InvalidArgumentError, "Unsupported tokenizer arg type: #{value.class}"
```

`InvalidArgumentError` is **not defined anywhere** in the gem (verified via `grep -rn "InvalidArgumentError"` — the only hit was this line). At runtime Ruby would raise `NameError: uninitialized constant ...` instead of a meaningful argument error, masking the real problem.

**Fix:** use Ruby's built-in `ArgumentError`. This matches how the rest of `migration_helpers.rb` already raises `ArgumentError` for bad tokenizer args.