### PR TITLE
chore: namespace Tokenizer as ParadeDB::Tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 
-- **BREAKING**: The `Tokenizer` class is now namespaced as `ParadeDB::Tokenizer`. Update references from `Tokenizer.simple(...)` to `ParadeDB::Tokenizer.simple(...)`. Schema dumps (`schema.rb`) now emit the fully-qualified constant. There is intentionally no top-level `Tokenizer` alias.
+- **BREAKING**: The `Tokenizer` class is now namespaced as `ParadeDB::Tokenizer`. Update references from `Tokenizer.simple(...)` to `ParadeDB::Tokenizer.simple(...)`. Schema dumps (`schema.rb`) now emit the fully-qualified constant.
 
 ## [0.7.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: The `Tokenizer` class is now namespaced as `ParadeDB::Tokenizer`. Update references from `Tokenizer.simple(...)` to `ParadeDB::Tokenizer.simple(...)`. Schema dumps (`schema.rb`) now emit the fully-qualified constant. There is intentionally no top-level `Tokenizer` alias.
+
 ## [0.7.0] - 2026-04-21
 
 ### Changed

--- a/examples/autocomplete/model.rb
+++ b/examples/autocomplete/model.rb
@@ -18,9 +18,9 @@ class MockItemIndex < ParadeDB::Index
     id: nil,
     description: nil,
     rating: nil,
-    category: { tokenizer: Tokenizer.literal() },
-    "metadata->>'color'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_color"}) },
-    "metadata->>'location'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_location"}) }
+    category: { tokenizer: ParadeDB::Tokenizer.literal() },
+    "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_color"}) },
+    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) }
   }
 end
 
@@ -39,10 +39,10 @@ class AutocompleteItemIndex < ParadeDB::Index
     id: nil,
     description: {
       tokenizers: [
-        Tokenizer.unicode_words(),
-        Tokenizer.ngram(3, 8, options: {alias: "description_ngram"})
+        ParadeDB::Tokenizer.unicode_words(),
+        ParadeDB::Tokenizer.ngram(3, 8, options: {alias: "description_ngram"})
       ]
     },
-    category: { tokenizer: Tokenizer.literal() }
+    category: { tokenizer: ParadeDB::Tokenizer.literal() }
   }
 end

--- a/examples/faceted_search/model.rb
+++ b/examples/faceted_search/model.rb
@@ -18,8 +18,8 @@ class MockItemIndex < ParadeDB::Index
     id: nil,
     description: nil,
     rating: nil,
-    category: { tokenizer: Tokenizer.literal() },
-    "metadata->>'color'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_color"}) },
-    "metadata->>'location'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_location"}) }
+    category: { tokenizer: ParadeDB::Tokenizer.literal() },
+    "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_color"}) },
+    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) }
   }
 end

--- a/examples/hybrid_rrf/model.rb
+++ b/examples/hybrid_rrf/model.rb
@@ -26,8 +26,8 @@ class MockItemIndex < ParadeDB::Index
     id: nil,
     description: nil,
     rating: nil,
-    category: { tokenizer: Tokenizer.literal() },
-    "metadata->>'color'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_color"}) },
-    "metadata->>'location'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_location"}) }
+    category: { tokenizer: ParadeDB::Tokenizer.literal() },
+    "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_color"}) },
+    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) }
   }
 end

--- a/examples/more_like_this/model.rb
+++ b/examples/more_like_this/model.rb
@@ -18,8 +18,8 @@ class MockItemIndex < ParadeDB::Index
     id: nil,
     description: nil,
     rating: nil,
-    category: { tokenizer: Tokenizer.literal() },
-    "metadata->>'color'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_color"}) },
-    "metadata->>'location'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_location"}) }
+    category: { tokenizer: ParadeDB::Tokenizer.literal() },
+    "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_color"}) },
+    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) }
   }
 end

--- a/examples/rag/model.rb
+++ b/examples/rag/model.rb
@@ -18,8 +18,8 @@ class MockItemIndex < ParadeDB::Index
     id: nil,
     description: nil,
     rating: nil,
-    category: { tokenizer: Tokenizer.literal() },
-    "metadata->>'color'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_color"}) },
-    "metadata->>'location'" => { tokenizer: Tokenizer.literal(options: {alias: "metadata_location"}) }
+    category: { tokenizer: ParadeDB::Tokenizer.literal() },
+    "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_color"}) },
+    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) }
   }
 end

--- a/lib/parade_db/arel/builder.rb
+++ b/lib/parade_db/arel/builder.rb
@@ -302,7 +302,7 @@ module ParadeDB
       def apply_tokenizer(node, tokenizer)
         return node if tokenizer.nil?
 
-        unless tokenizer.is_a?(Tokenizer)
+        unless tokenizer.is_a?(ParadeDB::Tokenizer)
           raise ArgumentError, "tokenizer must be a Tokenizer"
         end
 

--- a/lib/parade_db/index.rb
+++ b/lib/parade_db/index.rb
@@ -53,7 +53,7 @@ module ParadeDB
 
       class << self
         def parse(source_name, tokenizer, context:)
-          unless tokenizer.is_a?(Tokenizer)
+          unless tokenizer.is_a?(ParadeDB::Tokenizer)
             raise InvalidIndexDefinition, "#{context} for #{source_name.inspect} must be a Tokenizer"
           end
 

--- a/lib/parade_db/migration_helpers.rb
+++ b/lib/parade_db/migration_helpers.rb
@@ -695,13 +695,13 @@ module ParadeDB
     end
 
     def bm25_tokenizer_ruby(name, positional_args, options)
-      if name.match?(/\A[a-z_][a-z0-9_]*\z/) && Tokenizer.respond_to?(name)
+      if name.match?(/\A[a-z_][a-z0-9_]*\z/) && ParadeDB::Tokenizer.respond_to?(name)
         args = positional_args.map { |arg| ruby_literal(arg) }
         args << "options: #{ruby_hash_literal(options)}" unless options.empty?
-        return "Tokenizer.#{name}(#{args.join(', ')})"
+        return "ParadeDB::Tokenizer.#{name}(#{args.join(', ')})"
       end
 
-      "Tokenizer.new(#{name.inspect}, #{ruby_literal(positional_args.empty? ? nil : positional_args)}, #{ruby_literal(options.empty? ? nil : options)})"
+      "ParadeDB::Tokenizer.new(#{name.inspect}, #{ruby_literal(positional_args.empty? ? nil : positional_args)}, #{ruby_literal(options.empty? ? nil : options)})"
     end
 
     def split_sql_arguments(args_sql)

--- a/lib/parade_db/tokenizer.rb
+++ b/lib/parade_db/tokenizer.rb
@@ -1,95 +1,97 @@
-class Tokenizer
-  attr_reader :name, :positional_args, :options
+module ParadeDB
+  class Tokenizer
+    attr_reader :name, :positional_args, :options
 
-  def initialize(name, positional_args, options)
-    @name = name
-    @positional_args = positional_args
-    @options = options
-  end
-
-  def render()
-    if options.nil? && positional_args.nil?
-      return "pdb.#{name}"
+    def initialize(name, positional_args, options)
+      @name = name
+      @positional_args = positional_args
+      @options = options
     end
 
-    args = []
-    if !positional_args.nil?
-      args.concat(positional_args.map { |x| render_positional_arg(x) })
+    def render()
+      if options.nil? && positional_args.nil?
+        return "pdb.#{name}"
+      end
+
+      args = []
+      if !positional_args.nil?
+        args.concat(positional_args.map { |x| render_positional_arg(x) })
+      end
+      if !options.nil?
+        args.concat(options.map {|k, v| quote_term("#{k}=#{v}")})
+      end
+
+      return "pdb.#{name}(#{args.join(",")})"
     end
-    if !options.nil?
-      args.concat(options.map {|k, v| quote_term("#{k}=#{v}")})
+
+    def self.whitespace(options: nil)
+      new("whitespace", nil, options)
     end
 
-    return "pdb.#{name}(#{args.join(",")})"
-  end
+    def self.unicode_words(options: nil)
+      new("unicode_words", nil, options)
+    end
 
-  def self.whitespace(options: nil)
-    new("whitespace", nil, options)
-  end
+    def self.ngram(min_gram, max_gram, options: nil)
+      new("ngram", [min_gram, max_gram], options)
+    end
 
-  def self.unicode_words(options: nil)
-    new("unicode_words", nil, options)
-  end
+    def self.simple(options: nil)
+      new("simple", nil, options)
+    end
 
-  def self.ngram(min_gram, max_gram, options: nil)
-    new("ngram", [min_gram, max_gram], options)
-  end
+    def self.literal(options: nil)
+      new("literal", nil, options)
+    end
 
-  def self.simple(options: nil)
-    new("simple", nil, options)
-  end
+    def self.literal_normalized(options: nil)
+      new("literal_normalized", nil, options)
+    end
 
-  def self.literal(options: nil)
-    new("literal", nil, options)
-  end
+    def self.edge_ngram(min_gram, max_gram, options: nil)
+      new("edge_ngram", [min_gram, max_gram], options)
+    end
 
-  def self.literal_normalized(options: nil)
-    new("literal_normalized", nil, options)
-  end
+    def self.regex_pattern(pattern, options: nil)
+      new("regex_pattern", [pattern], options)
+    end
 
-  def self.edge_ngram(min_gram, max_gram, options: nil)
-    new("edge_ngram", [min_gram, max_gram], options)
-  end
+    def self.chinese_compatible(options: nil)
+      new("chinese_compatible", nil, options)
+    end
 
-  def self.regex_pattern(pattern, options: nil)
-    new("regex_pattern", [pattern], options)
-  end
+    def self.lindera(dictionary, options: nil)
+      new("lindera", [dictionary], options)
+    end
 
-  def self.chinese_compatible(options: nil)
-    new("chinese_compatible", nil, options)
-  end
+    def self.icu(options: nil)
+      new("icu", nil, options)
+    end
 
-  def self.lindera(dictionary, options: nil)
-    new("lindera", [dictionary], options)
-  end
+    def self.jieba(options: nil)
+      new("jieba", nil, options)
+    end
 
-  def self.icu(options: nil)
-    new("icu", nil, options)
-  end
+    def self.source_code(options: nil)
+      new("source_code", nil, options)
+    end
 
-  def self.jieba(options: nil)
-    new("jieba", nil, options)
-  end
+    private
 
-  def self.source_code(options: nil)
-    new("source_code", nil, options)
-  end
+    def quote_term(value)
+      escaped = value.gsub("'", "''")
+      "'#{escaped}'"
+    end
 
-  private
-
-  def quote_term(value)
-    escaped = value.gsub("'", "''")
-    "'#{escaped}'"
-  end
-
-  def render_positional_arg(value)
-    case value
-    when true, false, Numeric
-      value.to_s
-    when String
-      quote_term(value)
-    else
-      raise InvalidArgumentError, "Unsupported tokenizer arg type: #{value.class}"
+    def render_positional_arg(value)
+      case value
+      when true, false, Numeric
+        value.to_s
+      when String
+        quote_term(value)
+      else
+        raise InvalidArgumentError, "Unsupported tokenizer arg type: #{value.class}"
+      end
     end
   end
 end

--- a/spec/arel_builder_unit_spec.rb
+++ b/spec/arel_builder_unit_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe "ArelBuilderUnitTest" do
     assert_equal %("products"."description" &&& 'shoes'::pdb.boost(2.5)), sql(node)
   end
   it "match with tokenizer override" do
-    node = @builder.match(:description, "running shoes", tokenizer: Tokenizer.whitespace())
+    node = @builder.match(:description, "running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
     assert_equal %("products"."description" &&& 'running shoes'::pdb.whitespace), sql(node)
   end
   it "match with tokenizer override and args" do
-    node = @builder.match(:description, "running shoes", tokenizer: Tokenizer.whitespace(options: {lowercase: false}))
+    node = @builder.match(:description, "running shoes", tokenizer: ParadeDB::Tokenizer.whitespace(options: {lowercase: false}))
     assert_equal %("products"."description" &&& 'running shoes'::pdb.whitespace('lowercase=false')), sql(node)
   end
   it "match without boost" do
@@ -95,7 +95,7 @@ RSpec.describe "ArelBuilderUnitTest" do
     assert_equal %("products"."description" ### 'running shoes'::pdb.slop(10)), sql(node)
   end
   it "phrase with tokenizer override" do
-    node = @builder.phrase(:description, "running shoes", tokenizer: Tokenizer.whitespace())
+    node = @builder.phrase(:description, "running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
     assert_equal %("products"."description" ### 'running shoes'::pdb.whitespace), sql(node)
   end
   it "phrase with slop and constant score bridges through query" do

--- a/spec/arel_predications_unit_spec.rb
+++ b/spec/arel_predications_unit_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "ArelPredicationsUnitTest" do
     assert_equal %("products"."description" ### 'running shoes'::pdb.slop(10)), sql(node)
   end
   it "pdb_phrase with tokenizer" do
-    node = @t[:description].pdb_phrase("running shoes", tokenizer: Tokenizer.whitespace())
+    node = @t[:description].pdb_phrase("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
     assert_equal %("products"."description" ### 'running shoes'::pdb.whitespace), sql(node)
   end
   it "pdb_phrase with pretokenized array" do

--- a/spec/arel_visitor_spec.rb
+++ b/spec/arel_visitor_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "ArelVisitorTest" do
     assert_equal %("products"."description" ||| 'wireless bluetooth'), sql(node)
   end
   it "match any with tokenizer override" do
-    node = @builder.match_any(:description, "running shoes", tokenizer: Tokenizer.whitespace())
+    node = @builder.match_any(:description, "running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
     assert_equal %("products"."description" ||| 'running shoes'::pdb.whitespace), sql(node)
   end
   it "phrase with slop" do
@@ -27,7 +27,7 @@ RSpec.describe "ArelVisitorTest" do
     assert_equal %("products"."description" ### 'running shoes'::pdb.slop(2)), sql(node)
   end
   it "phrase with tokenizer" do
-    node = @builder.phrase(:description, "running shoes", tokenizer: Tokenizer.whitespace())
+    node = @builder.phrase(:description, "running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
     assert_equal %("products"."description" ### 'running shoes'::pdb.whitespace), sql(node)
   end
   it "phrase with array" do

--- a/spec/guards_integration_spec.rb
+++ b/spec/guards_integration_spec.rb
@@ -127,13 +127,13 @@ RSpec.describe "GuardsUnitTest" do
   end
   it "matching_any rejects tokenizer combined with fuzzy options" do
     error = assert_raises(ArgumentError) do
-      builder.match_any(:description, "shoes", tokenizer: Tokenizer.whitespace(), distance: 1)
+      builder.match_any(:description, "shoes", tokenizer: ParadeDB::Tokenizer.whitespace(), distance: 1)
     end
     assert_includes error.message, "tokenizer cannot be combined with fuzzy options"
   end
   it "matching_all rejects tokenizer combined with fuzzy options" do
     error = assert_raises(ArgumentError) do
-      builder.match(:description, "shoes", tokenizer: Tokenizer.whitespace(), prefix: true)
+      builder.match(:description, "shoes", tokenizer: ParadeDB::Tokenizer.whitespace(), prefix: true)
     end
     assert_includes error.message, "tokenizer cannot be combined with fuzzy options"
   end

--- a/spec/index_dsl_unit_spec.rb
+++ b/spec/index_dsl_unit_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "IndexDslUnitTest" do
         id: {},
         description: {
           tokenizers: [
-            Tokenizer.literal(),
-            Tokenizer.simple(options: {alias: "description_simple", lowercase: true})
+            ParadeDB::Tokenizer.literal(),
+            ParadeDB::Tokenizer.simple(options: {alias: "description_simple", lowercase: true})
           ]
         }
       }
@@ -32,7 +32,7 @@ RSpec.describe "IndexDslUnitTest" do
       self.where = "archived_at IS NULL"
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.simple() }
+        description: { tokenizer: ParadeDB::Tokenizer.simple() }
       }
     end
 
@@ -54,7 +54,7 @@ RSpec.describe "IndexDslUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.simple() }
+        description: { tokenizer: ParadeDB::Tokenizer.simple() }
       }
     end
 
@@ -73,8 +73,8 @@ RSpec.describe "IndexDslUnitTest" do
       self.fields = {
         id: {},
         description: {
-          tokenizers: [Tokenizer.literal()],
-          tokenizer: Tokenizer.simple()
+          tokenizers: [ParadeDB::Tokenizer.literal()],
+          tokenizer: ParadeDB::Tokenizer.simple()
         }
       }
     end
@@ -103,9 +103,9 @@ RSpec.describe "IndexDslUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.simple() },
-        category: { tokenizer: Tokenizer.literal() },
-        "metadata->>'title'" => { tokenizer: Tokenizer.simple(options: {alias: "metadata_title"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.simple() },
+        category: { tokenizer: ParadeDB::Tokenizer.literal() },
+        "metadata->>'title'" => { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "metadata_title"}) }
       }
     end
 
@@ -134,8 +134,8 @@ RSpec.describe "IndexDslUnitTest" do
         id: {},
         description: {
           tokenizers: [
-            Tokenizer.simple(),
-            Tokenizer.literal()
+            ParadeDB::Tokenizer.simple(),
+            ParadeDB::Tokenizer.literal()
           ]
         }
       }
@@ -154,8 +154,8 @@ RSpec.describe "IndexDslUnitTest" do
         id: {},
         description: {
           tokenizers: [
-            Tokenizer.simple(options: {alias: "description_simple"}),
-            Tokenizer.literal(options: {alias: "description_exact"})
+            ParadeDB::Tokenizer.simple(options: {alias: "description_simple"}),
+            ParadeDB::Tokenizer.literal(options: {alias: "description_exact"})
           ]
         }
       }
@@ -174,7 +174,7 @@ RSpec.describe "IndexDslUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.ngram(2, 5) }
+        description: { tokenizer: ParadeDB::Tokenizer.ngram(2, 5) }
       }
     end
 
@@ -192,7 +192,7 @@ RSpec.describe "IndexDslUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizers: [Tokenizer.literal(), :simple] }
+        description: { tokenizers: [ParadeDB::Tokenizer.literal(), :simple] }
       }
     end
 
@@ -206,8 +206,8 @@ RSpec.describe "IndexDslUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.new("pdb::xyz", nil, nil) },
-        "metadata->>'title'" => { tokenizer: Tokenizer.new("pdb::abc", [12, "fafda"], nil) }
+        description: { tokenizer: ParadeDB::Tokenizer.new("pdb::xyz", nil, nil) },
+        "metadata->>'title'" => { tokenizer: ParadeDB::Tokenizer.new("pdb::abc", [12, "fafda"], nil) }
       }
     end
 
@@ -226,7 +226,7 @@ RSpec.describe "IndexDslUnitTest" do
       self.fields = {
         id: {},
         description: {
-          tokenizer: Tokenizer.ngram(2, 5, options: {prefix_only: true, alias: "description_ngram"})
+          tokenizer: ParadeDB::Tokenizer.ngram(2, 5, options: {prefix_only: true, alias: "description_ngram"})
         }
       }
     end

--- a/spec/index_migration_integration_spec.rb
+++ b/spec/index_migration_integration_spec.rb
@@ -16,11 +16,11 @@ class IndexMigrationBookIndex < ParadeDB::Index
     id: {},
     title: {
       tokenizers: [
-        Tokenizer.literal(),
-        Tokenizer.simple(options: {alias: "title_simple", lowercase: true})
+        ParadeDB::Tokenizer.literal(),
+        ParadeDB::Tokenizer.simple(options: {alias: "title_simple", lowercase: true})
       ]
     },
-    author: { tokenizer: Tokenizer.literal() },
+    author: { tokenizer: ParadeDB::Tokenizer.literal() },
     metadata: { fast: true, expand_dots: false }
   }
 end
@@ -31,7 +31,7 @@ class IndexMigrationBookByNameIndex < ParadeDB::Index
   self.index_name = :books_by_name_bm25_idx
   self.fields = {
     id: {},
-    title: { tokenizer: Tokenizer.simple() }
+    title: { tokenizer: ParadeDB::Tokenizer.simple() }
   }
 end
 
@@ -95,8 +95,8 @@ RSpec.describe "IndexMigrationIntegrationTest" do
         id: {},
         title: {
           tokenizers: [
-            Tokenizer.literal(),
-            Tokenizer.simple()
+            ParadeDB::Tokenizer.literal(),
+            ParadeDB::Tokenizer.simple()
           ]
         }
       }
@@ -144,7 +144,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       self.where = "author IS NOT NULL"
       self.fields = {
         id: {},
-        title: { tokenizer: Tokenizer.simple() },
+        title: { tokenizer: ParadeDB::Tokenizer.simple() },
         author: {}
       }
     end
@@ -167,7 +167,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       :books,
       fields: {
         id: {},
-        title: { tokenizer: Tokenizer.simple() }
+        title: { tokenizer: ParadeDB::Tokenizer.simple() }
       },
       key_field: :id,
       name: :books_custom_bm25_idx,
@@ -187,7 +187,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       :books,
       fields: {
         id: {},
-        title: { tokenizer: Tokenizer.simple() }
+        title: { tokenizer: ParadeDB::Tokenizer.simple() }
       },
       key_field: :id,
       name: :books_partial_bm25_idx,
@@ -214,7 +214,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       :books,
       fields: {
         id: {},
-        title: { tokenizer: Tokenizer.simple() }
+        title: { tokenizer: ParadeDB::Tokenizer.simple() }
       },
       key_field: :id,
       name: :books_concurrent_bm25_idx,
@@ -252,7 +252,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
         :books,
         fields: {
           id: {},
-          title: { tokenizer: Tokenizer.simple() }
+          title: { tokenizer: ParadeDB::Tokenizer.simple() }
         },
         key_field: :id,
         name: :books_custom_bm25_idx,
@@ -292,7 +292,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        title: { tokenizer: Tokenizer.simple() }
+        title: { tokenizer: ParadeDB::Tokenizer.simple() }
       }
     end
     v2 = Class.new(ParadeDB::Index) do
@@ -300,8 +300,8 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        title: { tokenizer: Tokenizer.simple() },
-        author: { tokenizer: Tokenizer.literal() }
+        title: { tokenizer: ParadeDB::Tokenizer.simple() },
+        author: { tokenizer: ParadeDB::Tokenizer.literal() }
       }
     end
 
@@ -348,7 +348,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
           :books,
           fields: {
             id: {},
-            title: { tokenizer: Tokenizer.simple() }
+            title: { tokenizer: ParadeDB::Tokenizer.simple() }
           },
           key_field: :id,
           name: :books_concurrent_bm25_idx,
@@ -376,7 +376,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       :books,
       fields: {
         id: {},
-        title: { tokenizer: Tokenizer.simple(options: {alias: "title_simple"}) }
+        title: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "title_simple"}) }
       },
       key_field: :id,
       index_options: { target_segment_count: 17 },
@@ -395,7 +395,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
     end
 
     assert_equal <<~RUBY.strip, add_stmt.to_s.strip
-      add_bm25_index :books, fields: { id: {}, title: { tokenizer: Tokenizer.simple(options: { :alias => "title_simple" }) } }, key_field: :id, name: "books_bm25_idx", index_options: { :target_segment_count => 17 }
+      add_bm25_index :books, fields: { id: {}, title: { tokenizer: ParadeDB::Tokenizer.simple(options: { :alias => "title_simple" }) } }, key_field: :id, name: "books_bm25_idx", index_options: { :target_segment_count => 17 }
     RUBY
     expect(schema).not_to match(/add_index.*books_bm25_idx/)
     expect(schema).not_to match(/t\.index.*books_bm25_idx/)
@@ -411,7 +411,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       self.fields = {
         id: {},
         "(metadata->>'title')::text": {
-          tokenizer: Tokenizer.simple(options: {alias: "metadata_title"})
+          tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "metadata_title"})
         }
       }
     end
@@ -470,8 +470,8 @@ RSpec.describe "IndexMigrationIntegrationTest" do
         id: {},
         title: {
           tokenizers: [
-            Tokenizer.literal(),
-            Tokenizer.simple(options: {alias: "title_simple"})
+            ParadeDB::Tokenizer.literal(),
+            ParadeDB::Tokenizer.simple(options: {alias: "title_simple"})
           ]
         }
       },
@@ -490,7 +490,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
     end
 
     assert_equal <<~RUBY.strip, add_stmt.to_s.strip
-      add_bm25_index :books, fields: { id: {}, title: { tokenizers: [Tokenizer.literal(), Tokenizer.simple(options: { :alias => "title_simple" })] } }, key_field: :id, name: "books_bm25_idx", index_options: { :target_segment_count => 17 }
+      add_bm25_index :books, fields: { id: {}, title: { tokenizers: [ParadeDB::Tokenizer.literal(), ParadeDB::Tokenizer.simple(options: { :alias => "title_simple" })] } }, key_field: :id, name: "books_bm25_idx", index_options: { :target_segment_count => 17 }
     RUBY
 
     conn.remove_bm25_index(:books, if_exists: true)
@@ -507,7 +507,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       fields: {
         id: {},
         "(metadata->>'title')::text": {
-          tokenizer: Tokenizer.simple(options: {alias: "metadata_title_text", lowercase: true})
+          tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "metadata_title_text", lowercase: true})
         }
       },
       key_field: :id,
@@ -522,7 +522,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
     end
 
     assert_equal <<~RUBY.strip, add_stmt.to_s.strip
-      add_bm25_index :books, fields: { id: {}, "metadata ->> 'title'::text" => { tokenizer: Tokenizer.simple(options: { :lowercase => true, :alias => "metadata_title_text" }) } }, key_field: :id, name: "books_bm25_idx"
+      add_bm25_index :books, fields: { id: {}, "metadata ->> 'title'::text" => { tokenizer: ParadeDB::Tokenizer.simple(options: { :lowercase => true, :alias => "metadata_title_text" }) } }, key_field: :id, name: "books_bm25_idx"
     RUBY
 
     conn.remove_bm25_index(:books, if_exists: true)
@@ -538,7 +538,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
       :books,
       fields: {
         id: {},
-        title: { tokenizer: Tokenizer.simple(options: {alias: "title_simple"}) }
+        title: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "title_simple"}) }
       },
       key_field: :id,
       where: "author IS NOT NULL",
@@ -555,7 +555,7 @@ RSpec.describe "IndexMigrationIntegrationTest" do
     end
 
     assert_equal <<~RUBY.strip, add_stmt.to_s.strip
-      add_bm25_index :books, fields: { id: {}, title: { tokenizer: Tokenizer.simple(options: { :alias => "title_simple" }) } }, key_field: :id, name: "books_bm25_idx", where: "author IS NOT NULL"
+      add_bm25_index :books, fields: { id: {}, title: { tokenizer: ParadeDB::Tokenizer.simple(options: { :alias => "title_simple" }) } }, key_field: :id, name: "books_bm25_idx", where: "author IS NOT NULL"
     RUBY
 
     conn.remove_bm25_index(:books, if_exists: true)

--- a/spec/index_runtime_features_unit_spec.rb
+++ b/spec/index_runtime_features_unit_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "IndexRuntimeFeaturesUnitTest" do
       self.fields = {
         id: {},
         category: {},
-        description: { tokenizer: Tokenizer.simple(options: {alias: "description_simple"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "description_simple"}) }
       }
     end)
 
@@ -121,7 +121,7 @@ RSpec.describe "IndexRuntimeFeaturesUnitTest" do
       self.fields = {
         id: {},
         category: {},
-        description: { tokenizer: Tokenizer.simple(options: {alias: "description_simple"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "description_simple"}) }
       }
     end)
 
@@ -167,7 +167,7 @@ RSpec.describe "IndexRuntimeFeaturesUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.simple(options: {alias: "description_simple"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "description_simple"}) }
       }
     end)
 
@@ -192,7 +192,7 @@ RSpec.describe "IndexRuntimeFeaturesUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.literal(options: {alias: "description_exact"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "description_exact"}) }
       }
     end)
 
@@ -214,7 +214,7 @@ RSpec.describe "IndexRuntimeFeaturesUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.simple(options: {alias: "description_simple"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "description_simple"}) }
       }
     end)
 
@@ -243,7 +243,7 @@ RSpec.describe "IndexRuntimeFeaturesUnitTest" do
       self.key_field = :id
       self.fields = {
         id: {},
-        description: { tokenizer: Tokenizer.simple(options: {alias: "description_simple"}) }
+        description: { tokenizer: ParadeDB::Tokenizer.simple(options: {alias: "description_simple"}) }
       }
     end)
 

--- a/spec/key_field_runtime_integration_spec.rb
+++ b/spec/key_field_runtime_integration_spec.rb
@@ -12,7 +12,7 @@ class RuntimeKeyDocIndex < ParadeDB::Index
   self.key_field = :external_id
   self.fields = {
     external_id: {},
-    body: { tokenizer: Tokenizer.simple() },
+    body: { tokenizer: ParadeDB::Tokenizer.simple() },
     tag: {}
   }
 end

--- a/spec/user_api_behavior_integration_spec.rb
+++ b/spec/user_api_behavior_integration_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "UserApiBehaviorIntegrationTest" do
   end
   it "matching with tokenizer override executes" do
     ids = BehaviorProduct.search(:description)
-                         .matching_any("running shoes", tokenizer: Tokenizer.whitespace())
+                         .matching_any("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
                          .order(:id)
                          .pluck(:id)
 
@@ -56,21 +56,21 @@ RSpec.describe "UserApiBehaviorIntegrationTest" do
   end
   it "matching all with supported tokenizers matches raw SQL" do
     [
-      ["pdb.whitespace", Tokenizer.whitespace()],
-      ["pdb.whitespace('alias=my_column')", Tokenizer.whitespace(options: {alias: "my_column"})],
-      ["pdb.unicode_words", Tokenizer.unicode_words()],
-      ["pdb.literal", Tokenizer.literal()],
-      ["pdb.literal_normalized", Tokenizer.literal_normalized()],
-      ["pdb.ngram(3,3)", Tokenizer.ngram(3, 3)],
-      ["pdb.ngram(3,3,'positions=true')", Tokenizer.ngram(3, 3, options: {positions: true})],
-      ["pdb.edge_ngram(2,5)", Tokenizer.edge_ngram(2, 5)],
-      ["pdb.simple", Tokenizer.simple()],
-      ["pdb.regex_pattern('.*')", Tokenizer.regex_pattern('.*')],
-      ["pdb.chinese_compatible", Tokenizer.chinese_compatible()],
-      ["pdb.lindera('chinese')", Tokenizer.lindera('chinese')],
-      ["pdb.icu", Tokenizer.icu()],
-      ["pdb.jieba", Tokenizer.jieba()],
-      ["pdb.source_code", Tokenizer.source_code()]
+      ["pdb.whitespace", ParadeDB::Tokenizer.whitespace()],
+      ["pdb.whitespace('alias=my_column')", ParadeDB::Tokenizer.whitespace(options: {alias: "my_column"})],
+      ["pdb.unicode_words", ParadeDB::Tokenizer.unicode_words()],
+      ["pdb.literal", ParadeDB::Tokenizer.literal()],
+      ["pdb.literal_normalized", ParadeDB::Tokenizer.literal_normalized()],
+      ["pdb.ngram(3,3)", ParadeDB::Tokenizer.ngram(3, 3)],
+      ["pdb.ngram(3,3,'positions=true')", ParadeDB::Tokenizer.ngram(3, 3, options: {positions: true})],
+      ["pdb.edge_ngram(2,5)", ParadeDB::Tokenizer.edge_ngram(2, 5)],
+      ["pdb.simple", ParadeDB::Tokenizer.simple()],
+      ["pdb.regex_pattern('.*')", ParadeDB::Tokenizer.regex_pattern('.*')],
+      ["pdb.chinese_compatible", ParadeDB::Tokenizer.chinese_compatible()],
+      ["pdb.lindera('chinese')", ParadeDB::Tokenizer.lindera('chinese')],
+      ["pdb.icu", ParadeDB::Tokenizer.icu()],
+      ["pdb.jieba", ParadeDB::Tokenizer.jieba()],
+      ["pdb.source_code", ParadeDB::Tokenizer.source_code()]
     ].each do |expected, tokenizer|
       relation = BehaviorProduct.search(:description)
                                 .matching_all("running shoes", tokenizer: tokenizer)
@@ -88,7 +88,7 @@ RSpec.describe "UserApiBehaviorIntegrationTest" do
   it "matching with tokenizer + fuzzy distance raises argument error" do
     error = assert_raises(ArgumentError) do
       BehaviorProduct.search(:description)
-                     .matching_any("runing shose", tokenizer: Tokenizer.whitespace(), distance: 1)
+                     .matching_any("runing shose", tokenizer: ParadeDB::Tokenizer.whitespace(), distance: 1)
                      .order(:id)
                      .pluck(:id)
     end
@@ -97,7 +97,7 @@ RSpec.describe "UserApiBehaviorIntegrationTest" do
   it "matching with tokenizer + fuzzy constant score raises argument error" do
     error = assert_raises(ArgumentError) do
       BehaviorProduct.search(:description)
-                     .matching_any("runing shose", tokenizer: Tokenizer.whitespace(), distance: 1, constant_score: 1.0)
+                     .matching_any("runing shose", tokenizer: ParadeDB::Tokenizer.whitespace(), distance: 1, constant_score: 1.0)
                      .order(:id)
                      .pluck(:id)
     end
@@ -475,7 +475,7 @@ RSpec.describe "UserApiBehaviorIntegrationTest" do
       SQL
 
       relation = BehaviorProduct.search(:description)
-                                .phrase("running shoes", tokenizer: Tokenizer.whitespace())
+                                .phrase("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
                                 .order(:id)
 
       expected_ids = [1, 5]

--- a/spec/user_api_unit_spec.rb
+++ b/spec/user_api_unit_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe "UserApiUnitTest" do
     assert_sql_equal %(SELECT products.* FROM products WHERE ("products"."description" ||| 'wireless bluetooth')), sql
   end
   it "matching all with tokenizer override" do
-    sql = Product.search(:description).matching_all("running shoes", tokenizer: Tokenizer.whitespace()).to_sql
+    sql = Product.search(:description).matching_all("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace()).to_sql
     assert_sql_equal %(SELECT products.* FROM products WHERE ("products"."description" &&& 'running shoes'::pdb.whitespace)), sql
   end
   it "matching all with tokenizer args" do
-    sql = Product.search(:description).matching_all("running shoes", tokenizer: Tokenizer.whitespace(options: {lowercase: false})).to_sql
+    sql = Product.search(:description).matching_all("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace(options: {lowercase: false})).to_sql
     assert_sql_equal %(SELECT products.* FROM products WHERE ("products"."description" &&& 'running shoes'::pdb.whitespace('lowercase=false'))), sql
   end
   it "excluding terms" do
@@ -112,7 +112,7 @@ RSpec.describe "UserApiUnitTest" do
     assert_sql_equal %(SELECT products.* FROM products WHERE ("products"."description" ### 'running shoes'::pdb.slop(2))), sql
   end
   it "phrase with tokenizer" do
-    sql = Product.search(:description).phrase("running shoes", tokenizer: Tokenizer.whitespace()).to_sql
+    sql = Product.search(:description).phrase("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace()).to_sql
     assert_sql_equal %(SELECT products.* FROM products WHERE ("products"."description" ### 'running shoes'::pdb.whitespace)), sql
   end
   it "phrase with pretokenized array" do


### PR DESCRIPTION
## BREAKING CHANGE

The `Tokenizer` class was defined at the **global / `Object` namespace** (`lib/parade_db/tokenizer.rb:1` → `class Tokenizer`). A top-level constant like this risks colliding with other gems or application code that define their own `Tokenizer`.

This PR nests it under `module ParadeDB`, so it is now **`ParadeDB::Tokenizer`**.

### Migration

Update all references:

```ruby
# Before
Tokenizer.simple(options: { alias: "title_simple" })

# After
ParadeDB::Tokenizer.simple(options: { alias: "title_simple" })
```

There is **intentionally no top-level `Tokenizer` alias** — adding one would defeat the purpose of the fix (the collision risk would remain).

### Schema dumps

The schema dumper now emits the fully-qualified constant. Newly generated `schema.rb` files will contain `ParadeDB::Tokenizer.simple(...)` instead of `Tokenizer.simple(...)`. Re-run `db:schema:dump` (or regenerate) after upgrading; an existing `schema.rb` that still references bare `Tokenizer` will fail to load until regenerated or hand-edited.

## What changed

- `lib/parade_db/tokenizer.rb` — wrapped the class in `module ParadeDB` (re-indented; no logic change).
- `lib/parade_db/index.rb`, `lib/parade_db/arel/builder.rb` — `is_a?(Tokenizer)` → `is_a?(ParadeDB::Tokenizer)`.
- `lib/parade_db/migration_helpers.rb` — schema-dumper string generation now emits `ParadeDB::Tokenizer.<method>` / `ParadeDB::Tokenizer.new(...)`, and the `respond_to?` guard uses the qualified constant.
- `spec/**` — every `Tokenizer.<method>` / `Tokenizer.new` call (and the schema-dumper output-assertion strings) qualified to `ParadeDB::Tokenizer`.
- `examples/**/model.rb` — qualified to `ParadeDB::Tokenizer`.
- `CHANGELOG.md` — documented under `[Unreleased]`.

Conceptual/prose mentions of "Tokenizer" (e.g. the error message `"must be a Tokenizer"`, `non-Tokenizer` spec descriptions, `arel/README.md` prose) are intentionally left as-is — they refer to the concept, not the constant. README contains no `Tokenizer` code references.

## Verification

- `ruby -c` passes on all changed `.rb` files.
- Smoke test: after `require "parade_db/tokenizer"`, `ParadeDB::Tokenizer` is defined, the top-level `Tokenizer` constant is **not** defined, and `ParadeDB::Tokenizer.simple(options: {alias: "x"}).render` returns `pdb.simple('alias=x')`.
- rubocop is not installable in this environment (no write access to the system gem dir; bundler unavailable), so it was not run.
- The spec suite requires a live Postgres and was not run.

## Audit reference

Flagged in an automated code audit of `paradedb/rails-paradedb` (global-namespace `Tokenizer` collision risk).