### PR TITLE
fix: Remove max_term_frequency

### DIFF
--- a/examples/more_like_this/more_like_this.rb
+++ b/examples/more_like_this/more_like_this.rb
@@ -99,7 +99,6 @@ def demo_advanced_mlt_options
     min_term_freq: 1,
     max_query_terms: 12,
     min_doc_freq: 1,
-    max_term_freq: 100,
     max_doc_freq: 10_000,
     min_word_length: 3,
     max_word_length: 20,

--- a/lib/parade_db/search_methods.rb
+++ b/lib/parade_db/search_methods.rb
@@ -13,8 +13,6 @@ module ParadeDB
       max_query_terms: :max_query_terms,
       min_doc_freq: :min_doc_frequency,
       min_doc_frequency: :min_doc_frequency,
-      max_term_freq: :max_term_frequency,
-      max_term_frequency: :max_term_frequency,
       max_doc_freq: :max_doc_frequency,
       max_doc_frequency: :max_doc_frequency,
       min_word_length: :min_word_length,
@@ -25,7 +23,6 @@ module ParadeDB
       min_term_frequency
       max_query_terms
       min_doc_frequency
-      max_term_frequency
       max_doc_frequency
       min_word_length
       max_word_length
@@ -34,7 +31,6 @@ module ParadeDB
       min_term_frequency
       max_query_terms
       min_doc_frequency
-      max_term_frequency
       max_doc_frequency
       min_word_length
       max_word_length

--- a/spec/user_api_unit_spec.rb
+++ b/spec/user_api_unit_spec.rb
@@ -265,14 +265,13 @@ RSpec.describe "UserApiUnitTest" do
       min_term_freq: 2,
       max_query_terms: 10,
       min_doc_freq: 1,
-      max_term_freq: 20,
       max_doc_freq: 200,
       min_word_length: 3,
       max_word_length: 15,
       stopwords: %w[the a]
     ).to_sql
 
-    expected = %(SELECT products.* FROM products WHERE ("products"."id" @@@ pdb.more_like_this(5, ARRAY['description'], min_term_frequency => 2, max_query_terms => 10, min_doc_frequency => 1, max_term_frequency => 20, max_doc_frequency => 200, min_word_length => 3, max_word_length => 15, stopwords => ARRAY['the', 'a'])))
+    expected = %(SELECT products.* FROM products WHERE ("products"."id" @@@ pdb.more_like_this(5, ARRAY['description'], min_term_frequency => 2, max_query_terms => 10, min_doc_frequency => 1, max_doc_frequency => 200, min_word_length => 3, max_word_length => 15, stopwords => ARRAY['the', 'a'])))
     assert_sql_equal expected, sql
   end
   it "more like this key extraction does not fallback to id for non-id key fields" do


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This field isn't actually supported by ParadeDB, so it needs to be removed. See https://github.com/paradedb/tantivy/pull/149#issuecomment-4685612822.

## Why

## How

## Tests
