### PR TITLE
feat: support vector index build options (centroid_ratio, training_samples_per_centroid, cluster_replication)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- Vector index build options `centroid_ratio`, `training_samples_per_centroid`, and `cluster_replication` in `ParadeDB::Index` `index_options` and `add_paradedb_index` (pg_search 0.25.0+). They are emitted in the `WITH (...)` clause and round-tripped through the schema dumper.
+
 [0.10.0] - 2026-08-04
 
 ### Added

--- a/lib/parade_db/index.rb
+++ b/lib/parade_db/index.rb
@@ -83,6 +83,8 @@ module ParadeDB
     # Consumed by migration helpers; validates and normalizes the DSL class
     class DefinitionCompiler
       FIELD_OPTION_KEYS = %i[fast record normalizer expand_dots].freeze
+      INDEX_OPTION_KEYS = %i[target_segment_count centroid_ratio training_samples_per_centroid cluster_replication].freeze
+      POSITIVE_INTEGER_INDEX_OPTION_KEYS = %i[target_segment_count training_samples_per_centroid cluster_replication].freeze
 
       class Compiled
         attr_reader :table_name, :key_field, :index_name, :entries, :index_options, :field_options, :where
@@ -238,16 +240,26 @@ module ParadeDB
             memo[key.to_sym] = value
           end
 
-          unknown = normalized.keys - [:target_segment_count]
+          unknown = normalized.keys - INDEX_OPTION_KEYS
           unless unknown.empty?
             raise InvalidIndexDefinition,
                   "unknown index_options keys: #{unknown.map(&:inspect).join(', ')}"
           end
 
-          if normalized.key?(:target_segment_count)
-            target = normalized[:target_segment_count]
-            unless target.is_a?(Integer) && target.positive?
-              raise InvalidIndexDefinition, "index_options[:target_segment_count] must be an Integer > 0"
+          POSITIVE_INTEGER_INDEX_OPTION_KEYS.each do |key|
+            next unless normalized.key?(key)
+
+            value = normalized[key]
+            unless value.is_a?(Integer) && value.positive?
+              raise InvalidIndexDefinition, "index_options[#{key.inspect}] must be an Integer > 0"
+            end
+          end
+
+          if normalized.key?(:centroid_ratio)
+            ratio = normalized[:centroid_ratio]
+            unless ratio.is_a?(Numeric) && ratio >= 0.000001 && ratio <= 1.0
+              raise InvalidIndexDefinition,
+                    "index_options[:centroid_ratio] must be a Numeric between 0.000001 and 1.0"
             end
           end
 

--- a/lib/parade_db/migration_helpers.rb
+++ b/lib/parade_db/migration_helpers.rb
@@ -100,9 +100,12 @@ module ParadeDB
       options << "key_field=#{quote(compiled.key_field.to_s)}"
 
       compiled.index_options.each do |key, value|
-        case key.to_sym
-        when :target_segment_count
-          options << "target_segment_count=#{Integer(value)}"
+        name = key.to_sym
+        case name
+        when :target_segment_count, :training_samples_per_centroid, :cluster_replication
+          options << "#{name}=#{Integer(value)}"
+        when :centroid_ratio
+          options << "centroid_ratio=#{Float(value)}"
         else
           raise ParadeDB::InvalidIndexDefinition, "unsupported index option #{key.inspect}"
         end
@@ -297,6 +300,7 @@ module ParadeDB
           c.relname  AS index_name,
           t.relname  AS table_name,
           pg_get_indexdef(c.oid) AS indexdef,
+          array_to_json(c.reloptions)::text AS reloptions,
           pg_get_expr(i.indpred, i.indrelid) AS where_clause
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -319,7 +323,7 @@ module ParadeDB
       name = row["index_name"]
 
       key_field = extract_paradedb_key_field(indexdef)
-      index_options = extract_paradedb_index_options(indexdef)
+      index_options = extract_paradedb_index_options(row["reloptions"])
       fields_sql = extract_paradedb_fields_sql(indexdef)
       where = normalize_paradedb_where_clause(row["where_clause"])
 
@@ -369,27 +373,30 @@ module ParadeDB
       nil
     end
 
-    def extract_paradedb_index_options(indexdef)
-      with_sql, = extract_paradedb_with_components(indexdef)
-      options = {}
-      split_sql_arguments(with_sql).each do |argument|
-        key, value_sql = split_assignment(argument)
-        next if key.nil?
-        next if key == "key_field"
+    def extract_paradedb_index_options(reloptions)
+      paradedb_reloption_entries(reloptions).each_with_object({}) do |entry, options|
+        key, separator, value = entry.to_s.partition("=")
+        next if separator.empty?
 
         case key
-        when "target_segment_count"
-          parsed = parse_sql_literal(value_sql)
-          if parsed.is_a?(Integer)
-            options[:target_segment_count] = parsed
-          elsif parsed.is_a?(String) && parsed.match?(/\A\d+\z/)
-            options[:target_segment_count] = parsed.to_i
-          end
+        when "target_segment_count", "training_samples_per_centroid", "cluster_replication"
+          parsed = Integer(value, 10, exception: false)
+          options[key.to_sym] = parsed if parsed
+        when "centroid_ratio"
+          parsed = Float(value, exception: false)
+          options[:centroid_ratio] = parsed if parsed
         end
       end
-      options
-    rescue
-      {}
+    end
+
+    def paradedb_reloption_entries(reloptions)
+      case reloptions
+      when Array then reloptions
+      when String then Array(JSON.parse(reloptions))
+      else []
+      end
+    rescue JSON::ParserError
+      []
     end
 
     def extract_paradedb_fields_sql(indexdef)
@@ -408,27 +415,6 @@ module ParadeDB
       raise "Found invalid index definition `#{indexdef}`" if depth != 0
 
       indexdef[start..pos - 2]
-    end
-
-    def extract_paradedb_with_components(indexdef)
-      match = indexdef.match(/WITH\s*\(/im)
-      start = match.end(0)
-      depth = 1
-      pos = start
-      while pos < indexdef.length && depth > 0
-        case indexdef[pos]
-        when "(" then depth += 1
-        when ")" then depth -= 1
-        end
-        pos += 1
-      end
-      raise "Found invalid index definition `#{indexdef}`" if depth != 0
-
-      with_sql = indexdef[start..pos - 2]
-      trailing_sql = indexdef[pos..]&.strip
-      trailing_sql = nil if trailing_sql == ""
-
-      [with_sql, trailing_sql]
     end
 
     def normalize_paradedb_where_clause(where)

--- a/spec/index_dsl_unit_spec.rb
+++ b/spec/index_dsl_unit_spec.rb
@@ -25,6 +25,118 @@ RSpec.describe "IndexDslUnitTest" do
     assert_includes compiled.entries.map(&:query_key), "description_simple"
   end
 
+  it "compiles vector index build options and renders them in WITH" do
+    klass = Class.new(ParadeDB::Index) do
+      self.table_name = :products
+      self.key_field = :id
+      self.index_options = { centroid_ratio: 0.01, training_samples_per_centroid: 32, cluster_replication: 2 }
+      self.fields = { id: {}, description: nil, embedding: { metric: :cosine } }
+    end
+
+    compiled = klass.compiled_definition
+    assert_equal(
+      { centroid_ratio: 0.01, training_samples_per_centroid: 32, cluster_replication: 2 },
+      compiled.index_options
+    )
+
+    sql = ActiveRecord::Base.connection.send(:build_create_sql, compiled, if_not_exists: false)
+    assert_sql_equal <<~SQL, sql
+      CREATE INDEX products_search_idx ON products
+      USING paradedb (id, description, embedding vector_cosine_ops)
+      WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=2)
+    SQL
+  end
+
+  it "renders a single vector index build option in WITH" do
+    klass = Class.new(ParadeDB::Index) do
+      self.table_name = :products
+      self.key_field = :id
+      self.index_options = { centroid_ratio: 0.5 }
+      self.fields = { id: {}, description: nil }
+    end
+
+    sql = ActiveRecord::Base.connection.send(:build_create_sql, klass.compiled_definition, if_not_exists: false)
+    assert_sql_equal <<~SQL, sql
+      CREATE INDEX products_search_idx ON products
+      USING paradedb (id, description)
+      WITH (key_field='id', centroid_ratio=0.5)
+    SQL
+  end
+
+  it "rejects out-of-range and mistyped vector index build options" do
+    build = lambda do |options|
+      Class.new(ParadeDB::Index) do
+        self.table_name = :products
+        self.key_field = :id
+        self.index_options = options
+        self.fields = { id: {} }
+      end
+    end
+
+    [{ centroid_ratio: 0.0000001 }, { centroid_ratio: 1.5 }, { centroid_ratio: "0.01" }].each do |options|
+      error = assert_raises(ParadeDB::InvalidIndexDefinition) { build.call(options).compiled_definition }
+      assert_includes error.message, "centroid_ratio"
+      assert_includes error.message, "between 0.000001 and 1.0"
+    end
+
+    %i[training_samples_per_centroid cluster_replication].each do |key|
+      [0, -1, 1.5, "32"].each do |value|
+        error = assert_raises(ParadeDB::InvalidIndexDefinition) { build.call({ key => value }).compiled_definition }
+        assert_includes error.message, "index_options[#{key.inspect}] must be an Integer > 0"
+      end
+    end
+
+    error = assert_raises(ParadeDB::InvalidIndexDefinition) { build.call({ centroid: 0.01 }).compiled_definition }
+    assert_includes error.message, "unknown index_options keys"
+  end
+
+  it "parses vector index build options back from catalog reloptions" do
+    conn = ActiveRecord::Base.connection
+    indexdef = <<~SQL.squish
+      CREATE INDEX products_search_idx ON public.products
+      USING paradedb (id, description, embedding vector_cosine_ops)
+      WITH (key_field='id', centroid_ratio='0.01', training_samples_per_centroid='32', cluster_replication='2')
+    SQL
+
+    ruby_stmt = conn.send(
+      :paradedb_index_to_ruby,
+      {
+        "indexdef" => indexdef,
+        "table_name" => "products",
+        "index_name" => "products_search_idx",
+        "reloptions" => '["key_field=id","centroid_ratio=0.01","training_samples_per_centroid=32","cluster_replication=2"]'
+      }
+    )
+
+    assert_equal(
+      %(add_paradedb_index :products, fields: { id: {}, description: {}, embedding: { metric: :cosine } }, key_field: :id, name: "products_search_idx", index_options: { :centroid_ratio => 0.01, :training_samples_per_centroid => 32, :cluster_replication => 2 }),
+      ruby_stmt
+    )
+  end
+
+  it "extracts index options from reloptions entries, skipping unknown and malformed values" do
+    conn = ActiveRecord::Base.connection
+
+    options = conn.send(
+      :extract_paradedb_index_options,
+      ["key_field=id", "centroid_ratio=0.01", "training_samples_per_centroid=32", "cluster_replication=2"]
+    )
+    assert_equal(
+      { centroid_ratio: 0.01, training_samples_per_centroid: 32, cluster_replication: 2 },
+      options
+    )
+
+    assert_equal({}, conn.send(:extract_paradedb_index_options, nil))
+    assert_equal({}, conn.send(:extract_paradedb_index_options, "not json"))
+    assert_equal(
+      {},
+      conn.send(
+        :extract_paradedb_index_options,
+        ["key_field=id", "mystery=1", "centroid_ratio=abc", "training_samples_per_centroid=1.5", "cluster_replication"]
+      )
+    )
+  end
+
   it "compiles partial index predicates" do
     klass = Class.new(ParadeDB::Index) do
       self.table_name = :products
@@ -295,21 +407,6 @@ RSpec.describe "IndexDslUnitTest" do
       %(add_paradedb_index :products, fields: { id: {}, description: {} }, key_field: :id, name: "products_search_idx"),
       ruby_stmt
     )
-  end
-
-  it "parses nested parentheses in WITH clauses before trailing SQL" do
-    conn = ActiveRecord::Base.connection
-    indexdef = <<~SQL.squish
-      CREATE INDEX products_search_idx ON public.products
-      USING bm25 (id, description)
-      WITH (key_field=id, target_segment_count=((17)))
-      WHERE ((archived_at IS NULL))
-    SQL
-
-    with_sql, trailing_sql = conn.send(:extract_paradedb_with_components, indexdef)
-
-    assert_equal "key_field=id, target_segment_count=((17))", with_sql
-    assert_equal "WHERE ((archived_at IS NULL))", trailing_sql
   end
 
   it "exposes the paradedb migration helpers" do

--- a/spec/index_migration_integration_spec.rb
+++ b/spec/index_migration_integration_spec.rb
@@ -678,6 +678,32 @@ RSpec.describe "IndexMigrationIntegrationTest" do
     drop_mock_items!
   end
 
+  it "round-trips vector index build options through the schema dumper" do
+    create_mock_items!
+
+    conn = ActiveRecord::Base.connection
+    conn.add_paradedb_index(
+      :mock_items,
+      fields: { id: {}, description: {}, embedding: { metric: :cosine } },
+      key_field: :id,
+      index_options: { centroid_ratio: 0.01, training_samples_per_centroid: 32, cluster_replication: 1 }
+    )
+
+    add_stmt = dump_schema.each_line.find do |line|
+      line.include?("add_paradedb_index :mock_items")
+    end
+
+    assert_equal <<~RUBY.strip, add_stmt.to_s.strip
+      add_paradedb_index :mock_items, fields: { id: {}, description: {}, embedding: { metric: :cosine } }, key_field: :id, name: "mock_items_search_idx", index_options: { :centroid_ratio => 0.01, :training_samples_per_centroid => 32, :cluster_replication => 1 }
+    RUBY
+
+    conn.remove_paradedb_index(:mock_items, if_exists: true)
+    expect { conn.instance_eval(add_stmt.strip) }.not_to raise_error
+    assert index_exists?("mock_items_search_idx")
+  ensure
+    drop_mock_items!
+  end
+
   private
 
   def postgresql?


### PR DESCRIPTION
Exposes the pg_search 0.25.0+ vector index build options (`centroid_ratio`, `training_samples_per_centroid`, `cluster_replication`) through `index_options`, so the `WITH (...)` clause is expressible without raw SQL. Values are validated client-side like `target_segment_count`, and the options round-trip through the schema dumper.

```ruby
class ProductSearchIndex < ParadeDB::Index
  self.table_name = :products
  self.key_field = :id
  self.index_options = { centroid_ratio: 0.01, training_samples_per_centroid: 32, cluster_replication: 1 }
  self.fields = { id: {}, description: {}, embedding: { metric: :cosine } }
end

add_paradedb_index :products, fields: { id: {}, embedding: { metric: :cosine } },
  key_field: :id, index_options: { centroid_ratio: 0.01 }
```