### PR TITLE
fix(examples): use ParadeDB vector search in the hybrid RRF example

### DIFF
--- a/examples/hybrid_rrf/hybrid_rrf.rb
+++ b/examples/hybrid_rrf/hybrid_rrf.rb
@@ -25,9 +25,6 @@ end
 
 def semantic_ranked_cte(query_embedding, top_k:)
   distance = MockItem.paradedb_arel.cosine_distance(:embedding, query_embedding)
-  # nearest() orders by the index metric and adds `key_field @@@ pdb.all()`.
-  # That predicate is required: without a @@@ predicate the index cannot serve
-  # the query and Postgres falls back to a sequential scan.
   semantic_source = MockItem.nearest(:embedding, query_embedding)
                             .select(MockItem.arel_table[:id], distance.as("neighbor_distance"))
                             .limit(top_k)

--- a/examples/hybrid_rrf/hybrid_rrf.rb
+++ b/examples/hybrid_rrf/hybrid_rrf.rb
@@ -25,9 +25,11 @@ end
 
 def semantic_ranked_cte(query_embedding, top_k:)
   distance = MockItem.paradedb_arel.cosine_distance(:embedding, query_embedding)
-  semantic_source = MockItem.where.not(embedding: nil)
+  # nearest() orders by the index metric and adds `key_field @@@ pdb.all()`.
+  # That predicate is required: without a @@@ predicate the index cannot serve
+  # the query and Postgres falls back to a sequential scan.
+  semantic_source = MockItem.nearest(:embedding, query_embedding)
                             .select(MockItem.arel_table[:id], distance.as("neighbor_distance"))
-                            .order(distance.asc)
                             .limit(top_k)
 
   MockItem.from(semantic_source, :semantic_source)

--- a/examples/hybrid_rrf/model.rb
+++ b/examples/hybrid_rrf/model.rb
@@ -20,6 +20,7 @@ class MockItemIndex < ParadeDB::Index
     rating: nil,
     category: { tokenizer: ParadeDB::Tokenizer.literal() },
     "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_color"}) },
-    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) }
+    "metadata->>'location'" => { tokenizer: ParadeDB::Tokenizer.literal(options: {alias: "metadata_location"}) },
+    embedding: { metric: :cosine }
   }
 end


### PR DESCRIPTION
The recent vector search work put the vector column inside the ParadeDB index in every ORM, but some examples still query it the old way. This fixes the ones in this repo. Companion PRs are open in the other affected repos; sqlalchemy needed no change.

## The problem

For the ParadeDB index to serve a vector query, three things are required together: a `@@@` predicate, a distance operator matching the index opclass metric, and a `LIMIT`. Drop the `@@@` predicate and the query still returns correct rows, so nothing fails loudly — it just silently stops using the index and becomes a sequential scan plus a sort. That is exactly the vanilla pgvector behavior these examples are meant to show you how to avoid.

## Verification

Measured with `EXPLAIN` against ParadeDB 0.25.0. Before:

```text
Limit
  ->  Sort
        Sort Key: ((embedding <=> '[...]'::vector))
        ->  Seq Scan on mock_items
```

After:

```text
Limit
  ->  Custom Scan (ParadeDB Base Scan) on mock_items
        Table: mock_items
        Index: search_idx
        Exec Method: TopKScanExecState
        Scores: false
           TopK Order By: embedding <=> vector asc
           TopK Limit: 20
        Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
```

Every changed example was run end to end against a live ParadeDB container and produces sensible rankings.

## What changed here

**`examples/hybrid_rrf/model.rb`** — the index did not include the embedding column at all, so there was no indexed vector to sort by even with a correct predicate. Adds `embedding: { metric: :cosine }`, matching the metric the example already queries with and mirroring the rag example.

**`examples/hybrid_rrf/hybrid_rrf.rb`** — the semantic CTE filtered with `where.not(embedding: nil)`, a plain SQL predicate rather than a `@@@` one. Replaces it with `nearest(:embedding, ...)`, which orders by the index metric and adds `key_field @@@ pdb.all()`.

Ran end to end on Ruby 3.4; `rubocop --lint` is clean.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4
