### PR TITLE
docs: spell out Retrieval-Augmented Generation and name pg_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The official [ActiveRecord](https://guides.rubyonrails.org/active_record_basics.
 | Ruby       | 3.2+                                                               |
 | Rails      | 7.2+                                                               |
 | ParadeDB   | 0.25.0+                                                            |
-| PostgreSQL | 15+ (with ParadeDB extension)                                      |
+| PostgreSQL | 15+ (with the ParadeDB pg_search extension)                        |
 | pgvector   | Required for vector search (included in the ParadeDB Docker image) |
 
 ## Examples
@@ -54,7 +54,7 @@ The official [ActiveRecord](https://guides.rubyonrails.org/active_record_basics.
 - [Vector Search](examples/vector_search/vector_search.rb)
 - [Faceted Search](examples/faceted_search/faceted_search.rb)
 - [Hybrid Search (RRF)](examples/hybrid_rrf/hybrid_rrf.rb)
-- [RAG](examples/rag/rag.rb)
+- [Retrieval-Augmented Generation (RAG)](examples/rag/rag.rb)
 - [Autocomplete](examples/autocomplete/autocomplete.rb)
 - [More Like This](examples/more_like_this/more_like_this.rb)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ BUNDLE_GEMFILE=examples/Gemfile bundle exec ruby examples/hybrid_rrf/setup.rb
 BUNDLE_GEMFILE=examples/Gemfile bundle exec ruby examples/hybrid_rrf/hybrid_rrf.rb
 ```
 
-## RAG (`rag/rag.rb`)
+## Retrieval-Augmented Generation (RAG) (`rag/rag.rb`)
 
 A small question-answering flow. Retrieves products by combining full-text search with `nearest` vector retrieval, then sends the context to an LLM so answers are grounded in your own data.
 


### PR DESCRIPTION
- Expands **RAG** to **Retrieval-Augmented Generation (RAG)** in the README example list and the `examples/README.md` section heading, matching how **Hybrid Search (RRF)** already spells out its acronym.
- Names the extension explicitly in the PostgreSQL requirements row: `15+ (with the ParadeDB pg_search extension)`.

Applied identically across all five ORM integrations. Table column widths were re-flowed by prettier. markdownlint, prettier and codespell pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4