### PR TITLE
fix: declare the proximity and regex symbols rails already implements

### DIFF
--- a/api.json5
+++ b/api.json5
@@ -5,16 +5,20 @@
     "OP_OR":           "|||",
     "OP_PHRASE":       "###",
     "OP_PROXIMITY":    "##",
-    "OP_TERM":         "==="
+    "OP_TERM":         "===",
+    "OP_PROXIMITY_ORD": "##>"
   },
 
   "functions": {
     "FN_ALL":              "pdb.all",
     "FN_PARSE":            "pdb.parse",
     "FN_PHRASE_PREFIX":    "pdb.phrase_prefix",
+    "FN_REGEX_PHRASE":     "pdb.regex_phrase",
     "FN_REGEX":            "pdb.regex",
     "FN_MORE_LIKE_THIS":   "pdb.more_like_this",
     "FN_EXISTS":           "pdb.exists",
+    "FN_PROX_REGEX":       "pdb.prox_regex",
+    "FN_PROX_ARRAY":       "pdb.prox_array",
     "FN_RANGE":            "pdb.range",
     "FN_RANGE_TERM":       "pdb.range_term",
     "FN_TERM_SET":         "pdb.term_set",

--- a/apiignore.json5
+++ b/apiignore.json5
@@ -2,7 +2,6 @@
   "_comment": "Symbols present in the pg_search schema that rails-paradedb intentionally does not wrap. Remove an entry here when you add it to api.json. Sections can be either a flat list or grouped object of lists.",
 
   "operators": [
-    "##>"
   ],
 
   "functions": [
@@ -254,11 +253,7 @@
     "pdb.proximity_in_order",
 
     "pdb.term",
-    "pdb.regex_phrase",
-    "pdb.range_term",
     "pdb.proximity",
-    "pdb.prox_regex",
-    "pdb.prox_array",
     "pdb.empty",
     "pdb.fuzzy_term",
     "pdb.parse_with_field",


### PR DESCRIPTION
`apiignore.json5` records symbols a repo *"intentionally does not wrap"*. Several entries no longer matched reality, so the manifests misreported the supported API surface.

## rails was under-declaring four symbols it already implements

`##>` and `pdb.regex_phrase` / `pdb.prox_regex` / `pdb.prox_array` were listed as intentionally unwrapped — but all four are implemented and tested:

```ruby
# lib/parade_db/arel/builder.rb:390
operator = within_clause.ordered ? "##>" : "##"
```

`##>` is also in `PARADEDB_INFIX_OPERATORS`, in `PARADEDB_SQL_PATTERN`, and asserted in two specs (`'sleek' ##> 1 ##> 'shoes'`). The public `within(distance, *terms, ordered: true)` API produces it. The three functions appear in `lib/` and across **33 spec assertions**.

They're now declared as `OP_PROXIMITY_ORD`, `FN_REGEX_PHRASE`, `FN_PROX_REGEX` and `FN_PROX_ARRAY` — exactly what the other four repos already declare. **rails goes from 43 declared symbols to 47.**

## A symbol was in both manifests at once

`pdb.range_term` was wrapped as `FN_RANGE_TERM` *and* listed as intentionally unwrapped. That contradiction was introduced when `FN_RANGE_TERM` was added without dropping the stale ignore entry — my error in an earlier PR. Companion PRs fix the same `pdb.alias` contradiction in sqlalchemy, drizzle and efcore.

## Scope

**No behavior changes and no new API surface.** This only makes the manifests describe code that already exists — the earlier audit wrongly read `api.json5` in isolation and called these "coverage gaps" needing implementation.

## Verification

- `check_api_coverage.py` passes. That script confirms every *declared* symbol is genuinely referenced in source, so **47/47 referenced** is the evidence that the four promoted symbols are exercised rather than merely listed.
- No symbol appears in both manifests, in any of the five repos.
- prettier and codespell pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4