### PR TITLE
fix: use ParadeDB index terminology

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,13 +14,13 @@ end
 
 namespace :paradedb do
   namespace :diagnostics do
-    desc "List BM25 indexes from pdb.indexes()"
+    desc "List ParadeDB indexes from pdb.indexes()"
     task :indexes do
       rows = ParadeDB.paradedb_indexes(connection: paradedb_diagnostics_connection)
       puts JSON.pretty_generate(rows)
     end
 
-    desc "List BM25 index segments from pdb.index_segments(index)"
+    desc "List ParadeDB index segments from pdb.index_segments(index)"
     task :index_segments, [:index] do |_task, args|
       index = args[:index] || ENV["INDEX"]
       raise ArgumentError, "index is required (usage: rake paradedb:diagnostics:index_segments[my_index])" if index.nil? || index.strip.empty?

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,7 +53,7 @@ BUNDLE_GEMFILE=examples/Gemfile bundle exec ruby examples/faceted_search/faceted
 
 ## Hybrid Search (RRF) (`hybrid_rrf/hybrid_rrf.rb`)
 
-Combines BM25 keyword search (good for exact matches like part numbers) with vector similarity (good for meaning) using Reciprocal Rank Fusion. Composes a ParadeDB BM25 relation with a semantic relation via CTEs, using the native vector distance helpers.
+Combines BM25 keyword search (good for exact matches like part numbers) with vector similarity (good for meaning) using Reciprocal Rank Fusion. Composes a ParadeDB search relation with a semantic relation via CTEs, using the native vector distance helpers.
 
 Requires the `pgvector` extension, which is included in the ParadeDB Docker image.
 


### PR DESCRIPTION
Updates current Rake task descriptions and example wording from BM25 index/relation to ParadeDB index/search relation. Historical changelog entries and compatibility detection for the legacy `bm25` access method remain unchanged.

Validation: `ruby -c Rakefile` passes.